### PR TITLE
Updated Vagrantfile

### DIFF
--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -117,7 +117,7 @@ Vagrant.configure("2") do |config|
   	  esxi.guest_numvcpus = '2'
 	  #esxi.enable_vmrun_ip_lookup = 'False'
 	  esxi.guest_nic_type = 'vmxnet3'
-	  esxi_virtual_network = ['Corporate_LAN', 'INTERNET']
+	  esxi.virtual_network = ['Corporate_LAN', 'INTERNET']
       esxi.guest_mac_address = ["00:50:56:3f:02:01", "00:50:56:3f:02:02"]
       #v.gui = true
 	end
@@ -187,7 +187,7 @@ Vagrant.configure("2") do |config|
 	  esxi.guest_name = 'wef.windomain.local'
 	  esxi.guest_numvcpus = '2'
 	  esxi.guest_nic_type = 'vmxnet3'
-	  esxi_virtual_network = ['Corporate_LAN', 'INTERNET']
+	  esxi.virtual_network = ['Corporate_LAN', 'INTERNET']
       esxi.guest_mac_address = ["00:50:56:3f:03:01", "00:50:56:3f:03:02"]
 	end
   end
@@ -254,7 +254,7 @@ Vagrant.configure("2") do |config|
 	  esxi.guest_name = 'win10.windomain.local'
 	  esxi.guest_numvcpus = '1'
 	  esxi.guest_nic_type = 'vmxnet3'
-	  esxi_virtual_network = ['Corporate_LAN', 'INTERNET']
+	  esxi.virtual_network = ['Corporate_LAN', 'INTERNET']
       esxi.guest_mac_address = ["00:50:56:3f:04:01", "00:50:56:3f:04:02"]
 	end
   end

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -251,7 +251,7 @@ Vagrant.configure("2") do |config|
 	  esxi.esxi_username = 'ESXi_Username'
 	  esxi.esxi_password = 'ESXi_Password'
 	  esxi.guest_memsize = '2048'
-	  esxi.guest_name = 'wef.windomain.local'
+	  esxi.guest_name = 'win10.windomain.local'
 	  esxi.guest_numvcpus = '1'
 	  esxi.guest_nic_type = 'vmxnet3'
 	  esxi_virtual_network = ['Corporate_LAN', 'INTERNET']


### PR DESCRIPTION
esxi could not take in values for virtual_network[0] and virtual_network[1] due to typo "esxi_virtual_network".

win10 was not able to start due to existing name on wef.windomain.local.

Great work!